### PR TITLE
Added support to run the mock service on SSL. Important for browser-based consumers.

### DIFF
--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -52,7 +52,6 @@ module Pact
           :SSLEnable => true,
           :SSLCertName => [ %w[CN localhost] ] }) if options[:ssl]
 
-        puts options
         Rack::Handler::WEBrick.run(mock_service, webbrick_opts)
       end
     end


### PR DESCRIPTION
Very simple change to add a --ssl option to the mock_service CLI. Allows it to run with a self-signed certificate.

This is very helpful for testing browser-based consumers.
