### PR TITLE
bind webrick of consumer server to 0.0.0.0

### DIFF
--- a/lib/pact/consumer/server.rb
+++ b/lib/pact/consumer/server.rb
@@ -86,7 +86,7 @@ module Pact
     end
 
     def webrick_opts
-      opts = {Port: port.nil? ? 0 : port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0)}
+      opts = {Host: '0.0.0.0', Port: port.nil? ? 0 : port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0)}
       opts.merge!({
         :SSLCertificate => OpenSSL::X509::Certificate.new(File.open(options[:sslcert]).read) }) if options[:sslcert]
       opts.merge!({


### PR DESCRIPTION
My use case is hosting my test cases with their `Pact.service_consumer` mock in one of my docker-compose services, bind consumer server to '0.0.0.0' will fix the access between docker-compose services.