### PR TITLE
Always set 'Access-Control-Allow-Credentials: true' in preflight response

### DIFF
--- a/lib/pact/mock_service/request_handlers/options.rb
+++ b/lib/pact/mock_service/request_handlers/options.rb
@@ -9,6 +9,7 @@ module Pact
 
         HTTP_ACCESS_CONTROL_REQUEST_METHOD = "HTTP_ACCESS_CONTROL_REQUEST_METHOD".freeze
         HTTP_ACCESS_CONTROL_REQUEST_HEADERS = "HTTP_ACCESS_CONTROL_REQUEST_HEADERS".freeze
+        ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials".freeze
         ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin".freeze
         ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods".freeze
         ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers".freeze
@@ -30,6 +31,7 @@ module Pact
 
         def respond env
           cors_headers = {
+            ACCESS_CONTROL_ALLOW_CREDENTIALS => 'true',
             ACCESS_CONTROL_ALLOW_ORIGIN => env.fetch(HTTP_ORIGIN,'*'),
             ACCESS_CONTROL_ALLOW_HEADERS => env.fetch(HTTP_ACCESS_CONTROL_REQUEST_HEADERS, '*'),
             ACCESS_CONTROL_ALLOW_METHODS => ALL_METHODS

--- a/spec/lib/pact/mock_service/request_handlers/options_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/options_spec.rb
@@ -23,6 +23,7 @@ module Pact
             subject { response[1] }
 
             it { is_expected.to include 'Access-Control-Allow-Methods' => 'DELETE, POST, GET, HEAD, PUT, TRACE, CONNECT, PATCH' }
+            it { is_expected.to include 'Access-Control-Allow-Credentials' => 'true' }
 
             context "with Origin" do
               it { is_expected.to include 'Access-Control-Allow-Origin' => 'foo.com' }

--- a/spec/lib/pact/mock_service/request_handlers/options_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/options_spec.rb
@@ -23,7 +23,7 @@ module Pact
             subject { response[1] }
 
             it { is_expected.to include 'Access-Control-Allow-Methods' => 'DELETE, POST, GET, HEAD, PUT, TRACE, CONNECT, PATCH' }
-            it { is_expected.to include 'Access-Control-Allow-Credentials' => 'true' }
+            it { is_expected.to_not include 'Access-Control-Allow-Credentials' => 'true' }
 
             context "with Origin" do
               it { is_expected.to include 'Access-Control-Allow-Origin' => 'foo.com' }
@@ -47,6 +47,22 @@ module Pact
               let(:env) { {} }
 
               it { is_expected.to include 'Access-Control-Allow-Headers' => '*' }
+            end
+
+            context "with 'Authorization' in Access-Control-Request-Headers" do
+              before do
+                env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] = 'foo, Authorization, bar'
+              end
+
+              it { is_expected.to include 'Access-Control-Allow-Credentials' => 'true' }
+            end
+
+            context "with 'Cookie' in Access-Control-Request-Headers" do
+              before do
+                env['HTTP_ACCESS_CONTROL_REQUEST_HEADERS'] = 'foo, Cookie, bar'
+              end
+
+              it { is_expected.to include 'Access-Control-Allow-Credentials' => 'true' }
             end
           end
         end


### PR DESCRIPTION
Before sending credentials in cross origin requests, browsers expect the preflight response to contain the header `Access-Control-Allow-Credentials: true`.

According to [the fetch spec](https://fetch.spec.whatwg.org/#credentials), _"credentials are HTTP cookies, TLS client certificates, and authentication entries (for HTTP authentication)."_ From the mock service's point of view, whenever an OPTIONS request asks to include the "Cookie" or "Authorization" headers via `Access-Control-Request-Headers`, the consumer expects `Access-Control-Allow-Credentials` in the response.

This pull request simply always sets the header in preflight responses.

Drawbacks:
- Header is sent even when the browser does not expect it. The browsers I have met were tough and will be able to cope.

Alternatives would be:
- Only send header if `Access-Control-Request-Headers` contains `Cookie` or `Authorization`
- Make CORS behavior configurable per interaction