### PR TITLE
feat(mock-server) store providerStates in contract file

### DIFF
--- a/lib/pact/consumer_contract/interaction_decorator.rb
+++ b/lib/pact/consumer_contract/interaction_decorator.rb
@@ -15,6 +15,7 @@ module Pact
     def as_json options = {}
       hash = { :description => interaction.description }
       hash[:providerState] = interaction.provider_state if interaction.provider_state
+      hash[:providerStates] = interaction.provider_states if interaction.provider_states
       hash[:request] = decorate_request.as_json(options)
       hash[:response] = decorate_response.as_json(options)
       fix_all_the_things hash

--- a/lib/pact/mock_service/interaction_decorator.rb
+++ b/lib/pact/mock_service/interaction_decorator.rb
@@ -26,6 +26,7 @@ module Pact
       def to_hash
         hash = { :description => interaction.description }
         hash[:providerState] = interaction.provider_state if interaction.provider_state
+        hash[:providerStates] = interaction.provider_states if interaction.provider_states
         hash[:request] = decorate_request.as_json
         hash[:response] = decorate_response.as_json
         hash


### PR DESCRIPTION
Right now,`providerStates` are not serialized into a contract file if mockserver is started with `--pact_specification_version '3'`. This PR fixes the issue.