### PR TITLE
Improve logging robustness

### DIFF
--- a/lib/pact/mock_service/request_handlers/interaction_replay.rb
+++ b/lib/pact/mock_service/request_handlers/interaction_replay.rb
@@ -15,7 +15,7 @@ module Pact
         def pretty_generate object
           begin
             JSON.pretty_generate(JSON.parse(object.to_json))
-          rescue JSON::ParserError
+          rescue
             object
           end
         end

--- a/lib/pact/mock_service/request_handlers/interaction_replay.rb
+++ b/lib/pact/mock_service/request_handlers/interaction_replay.rb
@@ -16,7 +16,7 @@ module Pact
           begin
             JSON.pretty_generate(JSON.parse(object.to_json))
           rescue
-            object
+            object.to_s
           end
         end
       end

--- a/lib/pact/mock_service/request_handlers/interaction_replay.rb
+++ b/lib/pact/mock_service/request_handlers/interaction_replay.rb
@@ -13,7 +13,11 @@ module Pact
       module PrettyGenerate
         #Doesn't seem to reliably pretty generate unless we go to JSON and back again :(
         def pretty_generate object
-          JSON.pretty_generate(JSON.parse(object.to_json))
+          begin
+            JSON.pretty_generate(JSON.parse(object.to_json))
+          rescue JSON::ParserError
+            object
+          end
         end
       end
 

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -145,9 +145,6 @@ module Pact
           end
           
           context "when the body contains special charachters" do
-            let(:actual_body) { '\xEB' }
-            let(:expected_response_body) { '\xEB' }
-
             it "returns the specified response status" do
               expect(response_status).to eq 200
             end

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -175,6 +175,14 @@ module Pact
             expect(verified_interactions.size).to eq 0
           end
         end
+        
+        context "when the body contains special charachters" do
+          let(:actual_body) { '\xEB' }
+          
+          it "returns the specified response status" do
+              expect(response_status).to eq 200
+          end
+        end
       end
     end
   end

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -143,6 +143,14 @@ module Pact
               end
             end
           end
+          
+          context "when the body contains special charachters" do
+            let(:actual_body) { '\xEB' }
+
+            it "returns the specified response status" do
+              expect(response_status).to eq 200
+            end
+          end
         end
 
         context "when no request is found with a matching method and path" do
@@ -173,14 +181,6 @@ module Pact
           it "does not add the interaction to the verified interactions list" do
             response
             expect(verified_interactions.size).to eq 0
-          end
-        end
-        
-        context "when the body contains special charachters" do
-          let(:actual_body) { '\xEB' }
-          
-          it "returns the specified response status" do
-              expect(response_status).to eq 200
           end
         end
       end

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -146,7 +146,14 @@ module Pact
           
           context "when the body contains special charachters" do
             let(:actual_body) { '\xEB' }
-            let(:expected_request_body) { '\xEB' }
+            let(:env) do
+            {
+              'REQUEST_METHOD' => 'GET',
+              'PATH_INFO' => '/path',
+              'QUERY_STRING' => '',
+              'rack.input' => double(read: actual_body)
+            }
+            end
             
             it "returns the specified response status" do
               expect(response_status).to eq 200

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -145,6 +145,9 @@ module Pact
           end
           
           context "when the body contains special charachters" do
+            let(:actual_body) { '\xEB' }
+            let(:expected_request_body) { '\xEB' }
+            
             it "returns the specified response status" do
               expect(response_status).to eq 200
             end

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -146,6 +146,7 @@ module Pact
           
           context "when the body contains special charachters" do
             let(:actual_body) { '\xEB' }
+            let(:expected_response_body) { '\xEB' }
 
             it "returns the specified response status" do
               expect(response_status).to eq 200

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -146,9 +146,13 @@ module Pact
           
           context "when the body contains special charachters" do
             let(:actual_body) { '\xEB' }
+            
+            let(:expected_response_body) do
+              {"message"=>"No interaction found for GET /path", "interaction_diffs"=>[{"body"=>{"ACTUAL"=>"\\xEB", "EXPECTED"=>{"a"=>"body"}}, "description"=>"a request"}]}
+            end
+            
             it "returns the specified response status" do
               expect(response_status).to eq 500
-              expect(response_body).to include "No interaction found for "
             end
           end
         end

--- a/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
+++ b/spec/lib/pact/mock_service/request_handlers/interaction_replay_spec.rb
@@ -146,17 +146,9 @@ module Pact
           
           context "when the body contains special charachters" do
             let(:actual_body) { '\xEB' }
-            let(:env) do
-            {
-              'REQUEST_METHOD' => 'GET',
-              'PATH_INFO' => '/path',
-              'QUERY_STRING' => '',
-              'rack.input' => double(read: actual_body)
-            }
-            end
-            
             it "returns the specified response status" do
-              expect(response_status).to eq 200
+              expect(response_status).to eq 500
+              expect(response_body).to include "No interaction found for "
             end
           end
         end


### PR DESCRIPTION
Do not pretty print a JSON object when serialization or serialization fail, for details see #103.