### PR TITLE
feat: pact-stub-service log level cli opt

### DIFF
--- a/lib/pact/stub_service/cli.rb
+++ b/lib/pact/stub_service/cli.rb
@@ -27,6 +27,7 @@ module Pact
       method_option :port, aliases: "-p", desc: "Port on which to run the service"
       method_option :host, aliases: "-h", desc: "Host on which to bind the service", default: 'localhost'
       method_option :log, aliases: "-l", desc: "File to which to log output"
+      method_option :log_level, desc: "Log level. Options are DEBUG INFO WARN ERROR", default: "DEBUG"
       method_option :cors, aliases: "-o", desc: "Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses"
       method_option :ssl, desc: "Use a self-signed SSL cert to run the service over HTTPS", type: :boolean, default: false
       method_option :sslcert, desc: "Specify the path to the SSL cert to use when running the service over HTTPS"

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -84,7 +84,7 @@ def create_package(version, target, os_type = :unix)
   end
 
   sh "cp -pR build/vendor #{package_dir}/lib/"
-  sh "cp pact-mock-service.gemspec Gemfile Gemfile.lock #{package_dir}/lib/vendor/"
+  sh "cp pact-mock_service.gemspec Gemfile Gemfile.lock #{package_dir}/lib/vendor/"
   sh "mkdir #{package_dir}/lib/vendor/.bundle"
   sh "cp packaging/bundler-config #{package_dir}/lib/vendor/.bundle/config"
   if !ENV['DIR_ONLY']


### PR DESCRIPTION
Easy one, fixes #100 

```
➜  pact-mock_service git:(feat/stubservicelog) ✗ pact-stub-service --help
Usage:
  pact-stub-service PACT_URI ...

Options:
  -p, [--port=PORT]            # Port on which to run the service
  -h, [--host=HOST]            # Host on which to bind the service
                               # Default: localhost
  -l, [--log=LOG]              # File to which to log output
      [--log-level=LOG_LEVEL]  # Log level. Options are DEBUG INFO WARN ERROR
                               # Default: DEBUG
  -o, [--cors=CORS]            # Support browser security in tests by responding to OPTIONS requests and adding CORS headers to mocked responses
      [--ssl], [--no-ssl]      # Use a self-signed SSL cert to run the service over HTTPS
      [--sslcert=SSLCERT]      # Specify the path to the SSL cert to use when running the service over HTTPS
      [--sslkey=SSLKEY]        # Specify the path to the SSL key to use when running the service over HTTPS
```

Showing info level only, still shows registered expectations, matches and mis-matches, but doesn't log full bodies (ideal for our CI server as the log buffer gets filled up)

```
➜  pact-mock_service git:(feat/stubservicelog) ✗ pact-stub-service https://you54f.co.uk/pacts/provider/file-upload-service/consumer/test-consumer/latest --port=8080 --log-level=INFO
INFO: Loading interactions from https://you54f.co.uk/pacts/provider/file-upload-service/consumer/test-consumer/latest
I, [2019-05-01T00:55:27.366550 #92064]  INFO -- : Registered expected interaction POST /upload
I, [2019-05-01T00:55:27.366980 #92064]  INFO -- : Registered expected interaction POST /upload
INFO  WEBrick 1.3.1
INFO  ruby 2.2.6 (2016-11-15) [x86_64-darwin18]
INFO  WEBrick::HTTPServer#start: pid=92064 port=8080
I, [2019-05-01T00:55:30.282591 #92064]  INFO -- : Received request POST /upload
I, [2019-05-01T00:55:30.283843 #92064]  INFO -- : Found matching response for POST /upload
I, [2019-05-01T00:55:37.018832 #92064]  INFO -- : Received request POST /upload
E, [2019-05-01T00:55:37.019241 #92064] ERROR -- : No matching interaction found for POST /upload
E, [2019-05-01T00:55:37.019266 #92064] ERROR -- : Interaction diffs for that route:
E, [2019-05-01T00:55:37.019945 #92064] ERROR -- : Diff with interaction: "a well formed request with a base 64 encoded pdf to upload" given "Service is up and healthy"


Description of differences
--------------------------------------


@@ -1,7 +1,7 @@
 ----------------------------713166514119664968500586
 Content-Disposition: form-data; name="test"

-testd
+test
 ----------------------------713166514119664968500586
 Content-Disposition: form-data; name="document"; filename="test-base64.pdf"
 Content-Type: application/pdf

Diff with interaction: "a well formed request with a binary encoded pdf to upload" given "Service is up and healthy"


Description of differences
--------------------------------------




@@ -1,11 +1,22 @@
 ----------------------------713166514119664968500586
 Content-Disposition: form-data; name="test"

-testd
+test
 ----------------------------713166514119664968500586
-Content-Disposition: form-data; name="document"; filename="test-base64.pdf"
+Content-Disposition: form-data; name="document"; filename="test.pdf"
 Content-Type: application/pdf

-JVBERi0xLjIgCjkgMCBvYmoKPDwKPj4Kc3RyZWFtCkJULyA5IFRmKFRlc3QpJyBFVAplbmRzdHJlYW0KZW5kb2JqCjQgMCBvYmoKPDwKL1R5cGUgL1BhZ2UKL1BhcmVudCA1IDAgUgovQ29udGVudHMgOSAwIFIKPj4KZW5kb2JqCjUgMCBvYmoKPDwKL0tpZHMgWzQgMCBSIF0KL0NvdW50IDEKL1R5cGUgL1BhZ2VzCi9NZWRpYUJveCBbIDAgMCA5OSA5IF0KPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1BhZ2VzIDUgMCBSCi9UeXBlIC9DYXRhbG9nCj4+CmVuZG9iagp0cmFpbGVyCjw8Ci9Sb290IDMgMCBSCj4+CiUlRU9G
+%PDF-1.0
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 3 3]>>endobj
+xref
+0 4
+0000000000 65535 f
+0000000010 00000 n
+0000000053 00000 n
+0000000102 00000 n
+trailer<</Size 4/Root 1 0 R>>
+startxref
+149
+%EOF
 ----------------------------713166514119664968500586--
```