### PR TITLE
Support not writing interactions to pact file if marked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ log
 reports
 Gemfile.lock
 build
+.byebug_history
 
 vendor/bundle/
 spec/examples.txt

--- a/lib/pact/consumer_contract/consumer_contract_decorator.rb
+++ b/lib/pact/consumer_contract/consumer_contract_decorator.rb
@@ -32,11 +32,11 @@ module Pact
 
     def sorted_interactions
       # Default order: chronological
-      return consumer_contract.interactions if Pact.configuration.pactfile_write_order == :chronological
+      return consumer_contract.writable_interactions if Pact.configuration.pactfile_write_order == :chronological
       # We are supporting only chronological or alphabetical order
       raise NotImplementedError if Pact.configuration.pactfile_write_order != :alphabetical
 
-      consumer_contract.interactions.sort{|a, b| sortable_id(a) <=> sortable_id(b)}
+      consumer_contract.writable_interactions.sort{|a, b| sortable_id(a) <=> sortable_id(b)}
     end
 
     def sortable_id interaction

--- a/lib/pact/consumer_contract/interaction_decorator.rb
+++ b/lib/pact/consumer_contract/interaction_decorator.rb
@@ -17,6 +17,7 @@ module Pact
       hash[:providerState] = interaction.provider_state if interaction.provider_state
       hash[:request] = decorate_request.as_json(options)
       hash[:response] = decorate_response.as_json(options)
+      hash[:metadata] = interaction.metadata
       fix_all_the_things hash
     end
 

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'json'
   gem.add_runtime_dependency 'webrick', '~> 1.3'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
-  gem.add_runtime_dependency 'pact-support', '~> 1.2', '>= 1.2.1'
+  gem.add_runtime_dependency 'pact-support', '~> 1.12', '>= 1.12.0'
   gem.add_runtime_dependency 'filelock', '~> 1.1'
 
   gem.add_development_dependency 'rack-test', '~> 0.7'

--- a/spec/features/write_pact_file_spec.rb
+++ b/spec/features/write_pact_file_spec.rb
@@ -96,7 +96,7 @@ describe Pact::Consumer::MockService do
           status: 200
         },
         metadata: {
-          write_to_pact: true
+          write_to_pact: false
         }
       }.to_json
     end

--- a/spec/features/write_pact_file_spec.rb
+++ b/spec/features/write_pact_file_spec.rb
@@ -82,6 +82,47 @@ describe Pact::Consumer::MockService do
     end
   end
 
+  context "when the expected interaction is executed but is marked to not be written to the pact file" do
+    let(:zebra_interaction) do
+      {
+        description: "a request for zebras",
+        provider_state: "zebras exist",
+        request: {
+          method: :get,
+          path: '/zebras',
+          headers: {'Accept' => 'application/zebra'}
+        },
+        response: {
+          status: 200
+        },
+        metadata: {
+          write_to_pact: true
+        }
+      }.to_json
+    end
+
+    before do
+      post "/interactions", zebra_interaction, admin_headers
+    end
+
+    it "does not include the interaction in the pact file" do
+      get "/alligators", nil, {'HTTP_ACCEPT' => 'application/alligator'}
+      get "/giraffes", nil, {'HTTP_ACCEPT' => 'application/giraffe'}
+      get "/zebras", nil, {'HTTP_ACCEPT' => 'application/zebra'}
+      post "/pact", pact_details, admin_headers
+
+      expect(pact_json['interactions']).to include(
+        include("description" => "a request for alligators")
+      )
+      expect(pact_json['interactions']).to include(
+        include("description" => "a request for giraffes")
+      )
+      expect(pact_json['interactions']).to_not include(
+        include("description" => "a request for zebras")
+      )
+    end
+  end
+
   context "when no interactions are executed" do
     it "does not create the pact file" do
       post "/pact", pact_details, admin_headers


### PR DESCRIPTION
1) Added `metadata` to `InteractionDecorator`.
1) Changed `ConsumerContractDecorator#as_json` to use `ConsumerContract#writable_interactions`

See https://github.com/pact-foundation/pact-support/pull/75