### PR TITLE
Install thwait for ruby >= 2.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 rvm:
 - 2.2.4
 - 2.3.1
+- 2.7.0
 - jruby-9.0.5.0
 env:
   global:

--- a/lib/pact/mock_service/app_manager.rb
+++ b/lib/pact/mock_service/app_manager.rb
@@ -1,4 +1,4 @@
-require 'thwait' if RUBY_VERSION < '2.7'
+require 'thwait'
 
 require 'net/http'
 require 'uri'

--- a/lib/pact/mock_service/app_manager.rb
+++ b/lib/pact/mock_service/app_manager.rb
@@ -1,4 +1,4 @@
-require 'thwait'
+require 'thwait' if RUBY_VERSION < '2.7'
 
 require 'net/http'
 require 'uri'

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -20,17 +20,16 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
+  gem.add_runtime_dependency 'filelock', '~> 1.1'
+  gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
+  gem.add_runtime_dependency 'json'
+  gem.add_runtime_dependency 'pact-support', '~> 1.12', '>= 1.12.0'
   gem.add_runtime_dependency 'rack', '~> 2.0'
   gem.add_runtime_dependency 'rspec', '>=2.14'
-  gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
-  gem.add_runtime_dependency 'thor', '~> 0.19'
-  gem.add_runtime_dependency 'json'
-  gem.add_runtime_dependency 'webrick', '~> 1.3'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
-  gem.add_runtime_dependency 'pact-support', '~> 1.12', '>= 1.12.0'
-  gem.add_runtime_dependency 'filelock', '~> 1.1'
-
-  gem.add_runtime_dependency 'thwait', '~> 0.1.0', '< 1.0' if RUBY_VERSION >= '2.7'
+  gem.add_runtime_dependency 'thor', '~> 0.19'
+  gem.add_runtime_dependency 'thwait', '~> 0.1.0', '< 1.0'
+  gem.add_runtime_dependency 'webrick', '~> 1.3'
 
   gem.add_development_dependency 'rack-test', '~> 0.7'
   gem.add_development_dependency 'rake', '~> 10.0.3'

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'pact-support', '~> 1.12', '>= 1.12.0'
   gem.add_runtime_dependency 'filelock', '~> 1.1'
 
+  gem.add_runtime_dependency 'thwait', '~> 0.1.0', '< 1.0' if RUBY_VERSION >= '2.7'
+
   gem.add_development_dependency 'rack-test', '~> 0.7'
   gem.add_development_dependency 'rake', '~> 10.0.3'
   gem.add_development_dependency 'webmock', '~> 3.4'

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
+  gem.add_runtime_dependency 'e2mmap', '~> 0.1.0', '< 1.0'
   gem.add_runtime_dependency 'filelock', '~> 1.1'
   gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
   gem.add_runtime_dependency 'json'


### PR DESCRIPTION
## What

Check for ruby version to see if it is one that no longer includes `thwait` in the stlib. Install the gem of `thwait` if it is not in the ruby version. This is needed because ruby 2.7 has removed `thwait` from the standard library and is now installed via a gem.

## Changes

- Check ruby version for installing and requiring `thwait`

---
fixes #115 