### PR TITLE
Fix: Remove thwait require

### DIFF
--- a/lib/pact/mock_service/app_manager.rb
+++ b/lib/pact/mock_service/app_manager.rb
@@ -1,5 +1,3 @@
-require 'thwait'
-
 require 'net/http'
 require 'uri'
 require 'pact/logging'


### PR DESCRIPTION
## What

Ruby 2.7.x doesn't bundle thwait anymore so explicit require needs the thwait gem. But, it looks like removing the require shows that the dependency likely isn't needed.

## Changes

- Not needed and no longer bundled with ruby 2.7.x to be required

## Areas of concern

- Truly make sure this dependency isn't needed since it will break ruby version < 2.7 if it is.