### PR TITLE
Add expectations to make sure "metadata: nil" isn't stored in the pact

### DIFF
--- a/spec/features/write_pact_file_spec.rb
+++ b/spec/features/write_pact_file_spec.rb
@@ -69,6 +69,9 @@ describe Pact::Consumer::MockService do
       expect(pact_json['interactions']).to_not include(
         include("description" => "a request for alligators")
       )
+      expect(pact_json['interactions']).to_not include(
+        include("metadata" => nil)
+      )
     end
   end
 
@@ -78,6 +81,9 @@ describe Pact::Consumer::MockService do
       post "/pact", pact_details, admin_headers
       expect(pact_json['interactions']).to include(
         include("description" => "a request for alligators")
+      )
+      expect(pact_json['interactions']).to_not include(
+        include("metadata" => nil)
       )
     end
   end
@@ -119,6 +125,9 @@ describe Pact::Consumer::MockService do
       )
       expect(pact_json['interactions']).to_not include(
         include("description" => "a request for zebras")
+      )
+      expect(pact_json['interactions']).to_not include(
+        include("metadata" => nil)
       )
     end
   end


### PR DESCRIPTION
Adding expectations to test https://github.com/pact-foundation/pact-mock_service/commit/67ef5a6b774eb56d082cef137af3ef91ed193b53 following the changes originally made in https://github.com/pact-foundation/pact-mock_service/pull/113
