### PR TITLE
Update thor dependency

### DIFF
--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -9,6 +9,9 @@ require 'socket'
 module Pact
   module MockService
     class CLI < Thor
+      def self.exit_on_failure? # Thor 1.0 deprecation guard
+        false
+      end
 
       PACT_FILE_WRITE_MODE_DESC = "`overwrite` or `merge`. Use `merge` when running multiple mock service instances in parallel for the same consumer/provider pair." +
       " Ensure the pact file is deleted before running tests when using this option so that interactions deleted from the code are not maintained in the file."

--- a/lib/pact/mock_service/cli/custom_thor.rb
+++ b/lib/pact/mock_service/cli/custom_thor.rb
@@ -11,6 +11,9 @@ module Pact
       # `script --help` to display the help for the default task instead of the command list
       #
       class CustomThor < ::Thor
+        def self.exit_on_failure? # Thor 1.0 deprecation guard
+          false
+        end
 
         no_commands do
           def self.start given_args = ARGV, config = {}

--- a/lib/pact/mock_service/cli/pidfile.rb
+++ b/lib/pact/mock_service/cli/pidfile.rb
@@ -3,9 +3,11 @@ require 'fileutils'
 module Pact
   module MockService
     class CLI < Thor
+      def self.exit_on_failure? # Thor 1.0 deprecation guard
+        false
+      end
 
       class Pidfile
-
         attr_accessor :pid_dir, :name, :pid
 
         def initialize options

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rack', '~> 2.0'
   gem.add_runtime_dependency 'rspec', '>=2.14'
   gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
-  gem.add_runtime_dependency 'thor', '~> 0.19'
+  gem.add_runtime_dependency 'thor', '>= 0.19', '< 2.0'
   gem.add_runtime_dependency 'json'
   gem.add_runtime_dependency 'webrick', '~> 1.3'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'


### PR DESCRIPTION
Thor `1.0` is out, and we're using it with Pact on https://github.com/department-of-veterans-affairs/vets-api.

But we're having to maintain a fork to do so. This PR bumps the Thor dependency with a `< 2.0` max, imitating recent versions of Railties.

Feedback is welcome. Thank you!