### PR TITLE
Allow Host to be configured

### DIFF
--- a/lib/pact/consumer/server.rb
+++ b/lib/pact/consumer/server.rb
@@ -83,7 +83,7 @@ module Pact
     end
 
     def webrick_opts
-      opts = { Port: port.nil? ? 0 : port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0) }
+      opts = { Host: host.nil? ? 'localhost' : host, Port: port.nil? ? 0 : port, AccessLog: [], Logger: WEBrick::Log::new(nil, 0) }
       opts.merge!({
         :SSLCertificate => OpenSSL::X509::Certificate.new(File.open(options[:sslcert]).read) }) if options[:sslcert]
       opts.merge!({


### PR DESCRIPTION
In our testing, the host is not being passed when creating a new mock service. We were only ever able to create a server on localhost. This might fix the issue.