### PR TITLE
feat: update pact-support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gemspec
 if ENV['X_PACT_DEVELOPMENT']
   gem 'pact-support', path: '../pact-support'
 end
+
+gem 'pact-support', git: "https://github.com/joinhandshake/pact-support", ref: '0fa46bdaf27382a9eb86c9dfbcbca44d7b5e742c'

--- a/lib/pact/mock_service/version.rb
+++ b/lib/pact/mock_service/version.rb
@@ -1,5 +1,5 @@
 module Pact
   module MockService
-    VERSION = "3.9.1"
+    VERSION = "3.9.2"
   end
 end

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'thor', '>= 0.19', '< 2.0'
   gem.add_runtime_dependency 'json'
   gem.add_runtime_dependency 'webrick', '~> 1.3'
-  gem.add_runtime_dependency 'term-ansicolor', '~> 1.0'
-  gem.add_runtime_dependency 'pact-support', '~> 1.16', '>= 1.16.4'
+  gem.add_runtime_dependency 'pact-support', '~> 1.17.1', '>= 1.16.4'
   gem.add_runtime_dependency 'filelock', '~> 1.1'
 
   gem.add_development_dependency 'rack-test', '~> 0.7'


### PR DESCRIPTION
The `term-ansicolor` gem is not utilized in this package at all - it can be removed. The pact-support library should be pulled from the adjacent git repository for the time being to ensure that the `term-ansicolor` gem is not loaded.