### PR TITLE
Correct pact repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Description:
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md)
 
-[pact]: https://github.com/realestate-com-au/pact
+[pact]: https://github.com/pact-foundation/pact-ruby
 [executables]: https://github.com/pact-foundation/pact-ruby-standalone/releases
 [pact-dev]: https://groups.google.com/forum/#!forum/pact-dev
 [wiki]: https://github.com/pact-foundation/pact-mock_service/wiki


### PR DESCRIPTION
This updates an old link to be current

Also, the readme mentions the pact-dev google group - should that be slack?