### PR TITLE
fix: synchronize error when writing pact file, in Ruby 3.2.x

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -26,7 +26,7 @@ jobs:
       version: ${{ steps.release-gem.outputs.version }}
       increment: ${{ steps.release-gem.outputs.increment }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - id: release-gem

--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
     - run: "bundle install"
     - name: Test
       run: bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7","3.0","3.1","3.2","3.3.0-preview1"]
+        ruby_version: ["2.7","3.0","3.1","3.2"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7","3.0","3.1"]
+        ruby_version: ["2.7","3.0","3.1","3.2","3.3.0-preview1"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/lib/pact/consumer_contract/consumer_contract_writer.rb
+++ b/lib/pact/consumer_contract/consumer_contract_writer.rb
@@ -59,8 +59,7 @@ module Pact
     def update_pactfile
       logger.info log_message
       FileUtils.mkdir_p File.dirname(pactfile_path)
-      # update a counter using write lock
-      # don't use "w" because it truncates the file before lock.
+      # must be read after obtaining the lock, and must be read from the yielded file object, otherwise windows freaks out
       # https://apidock.com/ruby/File/flock
       File.open(pactfile_path, File::RDWR|File::CREAT, 0644) {|pact_file|
         pact_file.flock(File::LOCK_EX)

--- a/lib/pact/consumer_contract/consumer_contract_writer.rb
+++ b/lib/pact/consumer_contract/consumer_contract_writer.rb
@@ -61,6 +61,7 @@ module Pact
       FileUtils.mkdir_p File.dirname(pactfile_path)
       # update a counter using write lock
       # don't use "w" because it truncates the file before lock.
+      # https://apidock.com/ruby/File/flock
       File.open(pactfile_path, File::RDWR|File::CREAT, 0644) {|pact_file|
         pact_file.flock(File::LOCK_EX)
         @existing_contents = pact_file.read

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -25,9 +25,8 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
   gem.add_runtime_dependency 'thor', '>= 0.19', '< 2.0'
   gem.add_runtime_dependency 'json'
-  gem.add_runtime_dependency 'webrick', '~> 1.3'
+  gem.add_runtime_dependency 'webrick', '~> 1.8'
   gem.add_runtime_dependency 'pact-support', '~> 1.16', '>= 1.16.4'
-  gem.add_runtime_dependency 'filelock', '~> 1.1'
 
   gem.add_development_dependency 'rack-test', '~> 0.7'
   gem.add_development_dependency 'rake', '~> 13.0', '>= 13.0.1'

--- a/spec/features/log/mock_multiple_responses_spec.log
+++ b/spec/features/log/mock_multiple_responses_spec.log
@@ -1,103 +1,3 @@
-INFO -- : Cleared interactions for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
-INFO -- : Registered expected interaction GET /alligators
-DEBUG -- : {
-  "description": "a request for alligators",
-  "providerState": "alligators exist",
-  "request": {
-    "method": "get",
-    "path": "/alligators",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Mary"
-      }
-    ]
-  },
-  "metadata": null
-}
-INFO -- : Registered expected interaction GET /zebras
-DEBUG -- : {
-  "description": "a request for zebras",
-  "providerState": "there are zebras",
-  "request": {
-    "method": "get",
-    "path": "/zebras",
-    "headers": {
-      "Accept": "application/json"
-    }
-  },
-  "response": {
-    "status": 200,
-    "headers": {
-      "Content-Type": "application/json"
-    },
-    "body": [
-      {
-        "name": "Xena Zebra"
-      }
-    ]
-  },
-  "metadata": null
-}
-INFO -- : Received request GET /alligators
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/alligators",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /alligators
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Mary"
-    }
-  ]
-}
-INFO -- : Received request GET /zebras
-DEBUG -- : {
-  "method": "get",
-  "query": "",
-  "path": "/zebras",
-  "headers": {
-    "Https": "off",
-    "Content-Length": "0",
-    "Accept": "application/json",
-    "Host": "example.org",
-    "Cookie": ""
-  }
-}
-INFO -- : Found matching response for GET /zebras
-DEBUG -- : {
-  "status": 200,
-  "headers": {
-    "Content-Type": "application/json"
-  },
-  "body": [
-    {
-      "name": "Xena Zebra"
-    }
-  ]
-}
-INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
 INFO -- : Cleared interactions for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches more than one expected request returns an error response"
 INFO -- : Registered expected interaction GET /alligators
 DEBUG -- : {
@@ -216,3 +116,103 @@ WARN -- : Missing requests:
 
 
 
+INFO -- : Cleared interactions for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"
+INFO -- : Registered expected interaction GET /alligators
+DEBUG -- : {
+  "description": "a request for alligators",
+  "providerState": "alligators exist",
+  "request": {
+    "method": "get",
+    "path": "/alligators",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Mary"
+      }
+    ]
+  },
+  "metadata": null
+}
+INFO -- : Registered expected interaction GET /zebras
+DEBUG -- : {
+  "description": "a request for zebras",
+  "providerState": "there are zebras",
+  "request": {
+    "method": "get",
+    "path": "/zebras",
+    "headers": {
+      "Accept": "application/json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "body": [
+      {
+        "name": "Xena Zebra"
+      }
+    ]
+  },
+  "metadata": null
+}
+INFO -- : Received request GET /alligators
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/alligators",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /alligators
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Mary"
+    }
+  ]
+}
+INFO -- : Received request GET /zebras
+DEBUG -- : {
+  "method": "get",
+  "query": "",
+  "path": "/zebras",
+  "headers": {
+    "Https": "off",
+    "Content-Length": "0",
+    "Accept": "application/json",
+    "Host": "example.org",
+    "Cookie": ""
+  }
+}
+INFO -- : Found matching response for GET /zebras
+DEBUG -- : {
+  "status": 200,
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": [
+    {
+      "name": "Xena Zebra"
+    }
+  ]
+}
+INFO -- : Verifying - interactions matched for example "Pact::Consumer::MockService when more than one response has been mocked when the actual request matches one expected request returns the expected response"


### PR DESCRIPTION
Noted, in the pact-ruby-standalone upgrade to Ruby 3.2, fixes that :)

```console
Writing pact for Provider to tmp/pacts/consumer-provider.json
ERROR ThreadError: can't be called from trap context\n\t/Users/saf/.rbenv/versions/3.2.2/lib/ruby/3.2.0/timeout.rb:132:in `synchronize'
INFO  going to shutdown ...
INFO  WEBrick::HTTPServer#start done.
```