### PR TITLE
Add Rack 3 compatibility

### DIFF
--- a/lib/pact/consumer/server.rb
+++ b/lib/pact/consumer/server.rb
@@ -66,7 +66,11 @@ module Pact
     end
 
     def run_default_server(app, port)
-      require 'rack/handler/webrick'
+      begin
+        require 'rack/handler/webrick'
+      rescue LoadError
+        require 'rackup/handler/webrick'
+      end
       Rack::Handler::WEBrick.run(app, **webrick_opts) do |server|
         @port = server[:Port]
       end

--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -171,7 +171,11 @@ module Pact
 
         def require_common_dependencies
           require 'webrick/https'
-          require 'rack/handler/webrick'
+          begin
+            require 'rack/handler/webrick'
+          rescue LoadError
+            require 'rackup/handler/webrick'
+          end
           require 'fileutils'
           require 'pact/mock_service/server/wait_for_server_up'
           require 'pact/mock_service/cli/pidfile'

--- a/lib/pact/mock_service/request_handlers/interaction_post.rb
+++ b/lib/pact/mock_service/request_handlers/interaction_post.rb
@@ -21,7 +21,7 @@ module Pact
         end
 
         def respond env
-          request_body = env['rack.input'].string
+          request_body = env['rack.input'].read
           parsing_options = { pact_specification_version: pact_specification_version }
           interaction = Interaction.from_hash(JSON.load(request_body), parsing_options) # Load creates the Pact::XXX classes
 

--- a/lib/pact/stub_service/cli.rb
+++ b/lib/pact/stub_service/cli.rb
@@ -1,6 +1,10 @@
 require 'pact/mock_service/cli/custom_thor'
 require 'webrick/https'
-require 'rack/handler/webrick'
+begin
+  require 'rack/handler/webrick'
+rescue LoadError
+  require 'rackup/handler/webrick'
+end
 require 'fileutils'
 require 'pact/mock_service/server/wait_for_server_up'
 require 'pact/mock_service/cli/pidfile'

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'rack', '~> 2.0'
+  gem.add_runtime_dependency 'rack', '>= 2.0', '< 4.0'
+  gem.add_runtime_dependency 'rackup', '~> 2.0'
   gem.add_runtime_dependency 'rspec', '>=2.14'
   gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
   gem.add_runtime_dependency 'thor', '>= 0.19', '< 2.0'
@@ -28,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'webrick', '~> 1.8'
   gem.add_runtime_dependency 'pact-support', '~> 1.16', '>= 1.16.4'
 
-  gem.add_development_dependency 'rack-test', '~> 0.7'
+  gem.add_development_dependency 'rack-test', '>= 0.7', '< 3.0'
   gem.add_development_dependency 'rake', '~> 13.0', '>= 13.0.1'
   gem.add_development_dependency 'webmock', '~> 3.4'
   gem.add_development_dependency 'pry'

--- a/spec/integration/cli_spec.rb
+++ b/spec/integration/cli_spec.rb
@@ -13,6 +13,7 @@ describe "The pact-mock-service command line interface", mri_only: true, skip_wi
   it "starts up and responds with mocked responses" do
     response = setup_interaction 8888
     expect(response.status).to eq 200
+    expect(response.headers['X-Pact-Mock-Service-Location']).to eq 'http://0.0.0.0:8888'
 
     response = invoke_expected_request 8888
     puts response.body if response.status != 200
@@ -21,18 +22,15 @@ describe "The pact-mock-service command line interface", mri_only: true, skip_wi
 
     write_pact 8888
     expect(response.status).to eq 200
-  end
 
-  it "respects headers with underscores" do
     setup_interaction_with_underscored_header 8888
     response = invoke_request_with_underscored_header 8888
     puts response.body unless response.status == 200
     expect(response.status).to eq 200
-  end
 
-  it "sets the X-Pact-Mock-Service-Location header" do
-    response = setup_interaction 8888
-    expect(response.headers['X-Pact-Mock-Service-Location']).to eq 'http://0.0.0.0:8888'
+    Process.kill "INT", @pid
+    sleep 1 # Naughty, but so much less code
+    @pid = nil
   end
 
   it "writes logs to the specified log file" do
@@ -40,18 +38,10 @@ describe "The pact-mock-service command line interface", mri_only: true, skip_wi
   end
 
   it "writes the pact to the specified directory" do
-    clear_interactions 8888
-    setup_interaction 8888
-    invoke_expected_request 8888
     expect(File.exist?('tmp/pacts/consumer-provider.json')).to be true
   end
 
   it "sets the pact specification version" do
-    clear_interactions 8888
-    setup_interaction 8888
-    invoke_expected_request 8888
-
-    write_pact 8888
     expect(File.read("tmp/pacts/consumer-provider.json")).to include "3.0.0"
   end
 


### PR DESCRIPTION
This commit adds compatibility with Rack 3 and rack-test 2 while maintaining backwards compatibility.

Rack no longer depends on WEBrick since it's not a default gem in recent versions of Ruby, so add the Rackup gem to restore that functionality.

Use `read` instead of `string` to get the request body in a compatible way.

`spec/integration/cli_spec.rb` expected the pact files to get written before the server is shut down, whereas all the other similar specs, e.g. `spec/integration/control_server_cli_spec.rb`, shut the server down before expecting the files to be present. I'm not sure why exactly this works with Rack 2 but not Rack 3, or why it was just this one file that was different, but given all the other files follow the shut-down-the-server pattern, I changed this file to do the same. All of the assertions are still tested, the setup is the only thing that was changed.

Fixes https://github.com/pact-foundation/pact-mock_service/issues/145

There is at least one known security vulnerability in Rack 2 https://github.com/rack/rack/issues/1732 so releasing a new version with this change ASAP would be excellent.