### PR TITLE
Fix Rack 3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,10 @@ jobs:
       matrix:
         ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
+        rack_version: ["2", "3"]
     runs-on: ${{ matrix.os }}
+    env:
+      RACK_VERSION: ${{ matrix.rack_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1

--- a/lib/pact/consumer/mock_service/rack_request_helper.rb
+++ b/lib/pact/consumer/mock_service/rack_request_helper.rb
@@ -24,7 +24,7 @@ module Pact
         end
 
         request[:headers] = headers_from env
-        body_string = request[:body].read
+        body_string = request[:body]&.read || ""
 
         if body_string.empty?
           request.delete :body

--- a/lib/pact/consumer/server.rb
+++ b/lib/pact/consumer/server.rb
@@ -1,6 +1,7 @@
 require 'uri'
 require 'net/http'
 require 'rack'
+require 'rack/handler/webbrick'
 
 # Copied shamelessly from Capybara
 # Used to run a mock service in a new thread when started by the AppManager or the ControlServer
@@ -66,11 +67,6 @@ module Pact
     end
 
     def run_default_server(app, port)
-      begin
-        require 'rack/handler/webrick'
-      rescue LoadError
-        require 'rackup/handler/webrick'
-      end
       Rack::Handler::WEBrick.run(app, **webrick_opts) do |server|
         @port = server[:Port]
       end

--- a/lib/pact/mock_service/control_server/run.rb
+++ b/lib/pact/mock_service/control_server/run.rb
@@ -1,5 +1,6 @@
 require 'pact/mock_service/control_server/app'
 require 'pact/mock_service/server/webrick_request_monkeypatch'
+require 'rack/handler/webbrick'
 
 module Pact
   module MockService

--- a/lib/pact/mock_service/run.rb
+++ b/lib/pact/mock_service/run.rb
@@ -5,6 +5,7 @@ require 'pact/mock_service/run'
 require 'pact/mock_service/server/webrick_request_monkeypatch'
 require 'pact/specification_version'
 require 'pact/support/metrics'
+require 'rack/handler/webbrick'
 
 module Pact
   module MockService

--- a/lib/rack/handler/webbrick.rb
+++ b/lib/rack/handler/webbrick.rb
@@ -1,0 +1,12 @@
+module Rack
+  module Handler
+      begin
+        require 'rack/handler/webrick'
+        WEBrick = Class.new(Rack::Handler::WEBrick)
+      rescue LoadError
+        require 'rackup/handler/webrick'
+        WEBrick = Class.new(Rackup::Handler::WEBrick)
+      end
+  end
+end
+

--- a/pact-mock_service.gemspec
+++ b/pact-mock_service.gemspec
@@ -20,8 +20,12 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'rack', '>= 2.0', '< 4.0'
-  gem.add_runtime_dependency 'rackup', '~> 2.0'
+  if ENV['RACK_VERSION'] == '2'
+    gem.add_runtime_dependency 'rack', '>= 2.0', '< 3.0'
+  else
+    gem.add_runtime_dependency 'rack', '>= 3.0', '< 4.0'
+    gem.add_runtime_dependency 'rackup', '~> 2.0'
+  end
   gem.add_runtime_dependency 'rspec', '>=2.14'
   gem.add_runtime_dependency 'find_a_port', '~> 1.0.1'
   gem.add_runtime_dependency 'thor', '>= 0.19', '< 2.0'


### PR DESCRIPTION
Fixes https://github.com/pact-foundation/pact-mock_service/issues/151

As of Rack > 3.1.0, the previous fixes for `Rack::Handler::WEBrick` not being found have been removed. Additionally, [`rack.input` is now optional](https://github.com/rack/rack/blob/b4c92944e0dd04874bed36281fc8e1a44023677f/CHANGELOG.md?plain=1#L40), so we can't guarantee the `body` variable is there when reading the request in the mock service.

I've also updated the CI to run with both Rack `2.x.x` and `3.x.x`, so we can guarantee backwards compatibility. I imagine if we stopped support for Rack `2.x.x` completely this would cause issues with dependencies for some users.