### PR TITLE
fix: rack 2.x dont load Rack::Handler::WEBrick class to avoid warnings

### DIFF
--- a/lib/pact/mock_service/cli.rb
+++ b/lib/pact/mock_service/cli.rb
@@ -171,11 +171,7 @@ module Pact
 
         def require_common_dependencies
           require 'webrick/https'
-          begin
-            require 'rack/handler/webrick'
-          rescue LoadError
-            require 'rackup/handler/webrick'
-          end
+          require 'rack/handler/webbrick'
           require 'fileutils'
           require 'pact/mock_service/server/wait_for_server_up'
           require 'pact/mock_service/cli/pidfile'

--- a/lib/pact/stub_service/cli.rb
+++ b/lib/pact/stub_service/cli.rb
@@ -1,10 +1,6 @@
 require 'pact/mock_service/cli/custom_thor'
 require 'webrick/https'
-begin
-  require 'rack/handler/webrick'
-rescue LoadError
-  require 'rackup/handler/webrick'
-end
+require 'rack/handler/webbrick'
 require 'fileutils'
 require 'pact/mock_service/server/wait_for_server_up'
 require 'pact/mock_service/cli/pidfile'

--- a/lib/rack/handler/webbrick.rb
+++ b/lib/rack/handler/webbrick.rb
@@ -2,7 +2,6 @@ module Rack
   module Handler
       begin
         require 'rack/handler/webrick'
-        WEBrick = Class.new(Rack::Handler::WEBrick)
       rescue LoadError
         require 'rackup/handler/webrick'
         WEBrick = Class.new(Rackup::Handler::WEBrick)


### PR DESCRIPTION
use webbrick.rb custom handler in cli's


related to #152 

we get warnings when require'ing and using `Rack::Handler::WEBrick`. Removing this line removs teh warning, and tests all still pass

```console
lib/rack/handler/webbrick.rb:5: warning: already initialized constant Rack::Handler::WEBrick
.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/rack-2.2.9/lib/rack/handler/webrick.rb:25: warning: previous definition of WEBrick was here
```
