### PR TITLE
chore(ci): remove pact_broker client gem-released trigger

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -40,7 +40,7 @@ jobs:
     needs: release
     strategy:
       matrix:
-        repository: [pact-foundation/pact-ruby-cli, pact-foundation/pact-ruby-standalone, pact-foundation/pact_broker-client]
+        repository: [pact-foundation/pact-ruby-cli, pact-foundation/pact-ruby-standalone]
     runs-on: ubuntu-latest
     steps:
       - name: Notify ${{ matrix.repository }} of gem release


### PR DESCRIPTION
pact_broker-client, has a workflow for [gem-released](https://github.com/pact-foundation/pact_broker-client/tree/master/.github/workflows)

This triggers a [doc update](https://github.com/pact-foundation/pact_broker-client/blob/master/.github/workflows/trigger_pact_docs_update.yml) in docs.pact.io

I believe this isnt required as

- not in [deps](https://github.com/pact-foundation/pact_broker-client/blob/master/Gemfile#L10) or listed in [rubygems](https://rubygems.org/gems/pact_broker-client)

Apart from [`X_PACT_DEVELOPMENT`](https://github.com/pact-foundation/pact_broker-client/blob/master/Gemfile#L10)

Which should be updated to include `pact` which does in turn rely on `pact-mock_service`

And the docs from this readme are not currently synced to the docs.pact.io site