### PR TITLE
fix: pass pact spec to matching rules extract func

### DIFF
--- a/lib/pact/consumer_contract/request_decorator.rb
+++ b/lib/pact/consumer_contract/request_decorator.rb
@@ -75,7 +75,7 @@ module Pact
     end
 
     def with_matching_rules hash
-      matching_rules = Pact::MatchingRules.extract request.to_hash
+      matching_rules = Pact::MatchingRules.extract(request.to_hash, pact_specification_version: Pact::SpecificationVersion.new(pact_specification_version))
       return hash if matching_rules.empty?
       hash.merge(matchingRules: matching_rules)
     end

--- a/lib/pact/consumer_contract/response_decorator.rb
+++ b/lib/pact/consumer_contract/response_decorator.rb
@@ -34,7 +34,7 @@ module Pact
     end
 
     def with_matching_rules hash
-      matching_rules = Pact::MatchingRules.extract hash
+      matching_rules = Pact::MatchingRules.extract(hash, pact_specification_version: Pact::SpecificationVersion.new(pact_specification_version))
       example = Pact::Reification.from_term hash
       return example if matching_rules.empty?
       example.merge(matchingRules: matching_rules)


### PR DESCRIPTION
note matching rules are written incorrectly

current behaviour

```json
"matchingRules": {
  "$.body.company": {
    "matchers": [
      {
        "match": "type"
      }
    ]
  },
  "$.body.factories": {
    "matchers": [
      {
        "min": 1
      }
    ]
  },
  "$.body.factories[*].*": {
    "matchers": [
      {
        "match": "type"
      }
    ]
  }
}
```

expected behaviour

```json
"matchingRules": {
  "body":{
    "$.company": {
      "matchers": [
        {
          "match": "type"
        }
      ]
    },
    "$.factories": {
      "matchers": [
        {
          "min": 1
        }
      ]
    },
    "$.factories[*].*": {
      "matchers": [
        {
          "match": "type"
        }
      ]
    }
  }
}
```