### PR TITLE
fix: remove unnecessary require

### DIFF
--- a/lib/pact/consumer/mock_service/rack_request_helper.rb
+++ b/lib/pact/consumer/mock_service/rack_request_helper.rb
@@ -1,4 +1,3 @@
-require 'cgi/core'
 require 'pact/consumer_contract/query'
 
 module Pact


### PR DESCRIPTION
We saw a build failure related to pact after upgrading our apps to Ruby 4 due to removal of the `cgi` library from standard gems. Seems like this require statement was left in after the code was refactored to use `Pact::Query`.